### PR TITLE
Adding polle package

### DIFF
--- a/CausalInference.md
+++ b/CausalInference.md
@@ -247,7 +247,13 @@ treatment effect (HTE) estimation.
     estimation of individualized treatment rules from observational and
     randomized data with options for variable-selection and gradient boosting
     based estimation, and for outcome model augmentation (for continuous,
-    binary, count, and time-to-event outcomes).
+    binary, count, and time-to-event outcomes). 
+    `r pkg("polle")` provides a unified framework for
+    learning and evaluating finite stage policies based on observational data
+    with methods such as doubly robust restricted Q-learning, policy tree
+    learning,  and outcome weighted learning. Flexible machine learning methods
+    can be used to estimate the nuisance components and valid inference for the 
+    policy value is ensured via cross-fitting.
 -   Estimation of DTR with *variable selection* is proposed by
     `r pkg("ITRLearn")` implements maximin-projection learning
     for recommending a meaningful and reliable individualized treatment


### PR DESCRIPTION
The polle package provides a unified framework for policy learning in R and implements both new methods and wraps methods from other R packages, which makes the different policy learning methods much more user friendly.
The package is described in details here: https://arxiv.org/abs/2212.02335.
